### PR TITLE
Change permissions to prevent tablet exclusion

### DIFF
--- a/timodule.xml
+++ b/timodule.xml
@@ -9,9 +9,9 @@
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 	    <manifest>
 			<uses-permission android:name="android.permission.CAMERA" />
-			<uses-feature android:name="android.hardware.camera" />
-			<uses-feature android:name="android.hardware.camera.autofocus" />
-			<uses-feature android:name="android.hardware.camera.flash" />
+			<uses-feature android:name="android.hardware.camera" required="false" />
+			<uses-feature android:name="android.hardware.camera.autofocus" required="false" />
+			<uses-feature android:name="android.hardware.camera.flash" required="false" />
 		</manifest>
 	</android>
 	<mobileweb>


### PR DESCRIPTION
This module made the app excluded for all tablets that doesn't provide flash or autofocus
